### PR TITLE
Use plugin for top-level resolution per entry

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -6,6 +6,7 @@ const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const FriendlyErrorsWebpackPlugin = require("friendly-errors-webpack-plugin");
 const WatchMissingNodeModulesPlugin = require("react-dev-utils/WatchMissingNodeModulesPlugin");
 const PrettierPlugin = require("prettier-webpack-plugin");
+const ResolveEntryModulesPlugin = require("resolve-entry-modules-webpack-plugin");
 const atImport = require("postcss-import");
 const postcssURL = require("postcss-url");
 const cssNext = require("postcss-cssnext");
@@ -105,10 +106,7 @@ module.exports = {
     // if there are any conflicts. This matches Node resolution mechanism.
     // https://github.com/facebookincubator/create-react-app/issues/253
     modules: ["node_modules"]
-      .concat(paths.nodePaths)
-      // Expose the appEntryDirs as a resolution point so that we can resolve
-      // from the root of each entry point and avoid relative requires
-      .concat(paths.appEntryDirs),
+      .concat(paths.nodePaths),
     // These are the reasonable defaults supported by the Node ecosystem.
     // We also include JSX as a common component filename extension to support
     // some tools, although we do not recommend using it, see:
@@ -252,6 +250,9 @@ module.exports = {
     // Makes some environment variables available to the JS code, for example:
     // if (process.env.NODE_ENV === 'development') { ... }. See `./env.js`.
     new webpack.DefinePlugin(env.stringified),
+    // Expose each entry as a resolution point so that we can resolve from the
+    // root of each entry point and avoid relative requires
+    new ResolveEntryModulesPlugin(),
     // This is necessary to emit hot updates (currently CSS only):
     // Disabled until the ExtractText plugin supports HMR
     // https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/592

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -85,10 +85,7 @@ module.exports = {
     // if there are any conflicts. This matches Node resolution mechanism.
     // https://github.com/facebookincubator/create-react-app/issues/253
     modules: ['node_modules']
-      .concat(paths.nodePaths)
-      // Expose the appEntryDirs as a resolution point so that we can resolve
-      // from the root of each entry point and avoid relative requires
-      .concat(paths.appEntryDirs),
+      .concat(paths.nodePaths),
     // These are the reasonable defaults supported by the Node ecosystem.
     // We also include JSX as a common component filename extension to support
     // some tools, although we do not recommend using it, see:

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "prettier-webpack-plugin": "^0.2.2",
     "promise": "8.0.1",
     "react-dev-utils": "^4.0.1",
+    "resolve-entry-modules-webpack-plugin": "^1.0.1",
     "style-loader": "0.18.2",
     "webpack": "3.10.0",
     "webpack-dev-server": "2.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1582,6 +1582,13 @@ contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
+contains-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-1.0.0.tgz#3458b332185603e8eed18f518d4a10888a3abc91"
+  dependencies:
+    normalize-path "^2.1.1"
+    path-starts-with "^1.0.0"
+
 content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
@@ -3963,6 +3970,10 @@ lodash.uniq@^4.3.0, lodash.uniq@^4.5.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.5:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 loglevel@^1.4.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.5.0.tgz#3863984a2c326b986fbb965f378758a6dc8a4324"
@@ -4238,6 +4249,12 @@ normalize-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
 
+normalize-path@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  dependencies:
+    remove-trailing-separator "^1.0.1"
+
 normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
@@ -4481,6 +4498,12 @@ path-key@^2.0.0:
 path-parse@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
+path-starts-with@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/path-starts-with/-/path-starts-with-1.0.0.tgz#b28243015e8b138de572682ac52da42e646ad84e"
+  dependencies:
+    normalize-path "^2.1.1"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -5455,6 +5478,10 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
+remove-trailing-separator@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+
 repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
@@ -5525,9 +5552,21 @@ resolve-dir@^1.0.0:
     expand-tilde "^2.0.0"
     global-modules "^1.0.0"
 
+resolve-entry-modules-webpack-plugin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-entry-modules-webpack-plugin/-/resolve-entry-modules-webpack-plugin-1.0.1.tgz#8b982fdbd2c024879374eda5f8c4e8a2ddc4bc7a"
+  dependencies:
+    contains-path "^1.0.0"
+    lodash "^4.17.5"
+    resolve-from "^4.0.0"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
 
 resolve@1.1.7:
   version "1.1.7"


### PR DESCRIPTION
We had been including each entry directory as a resolution point for webpack so that we could require modules from the top-level entry directories down. Unfortunately that meant same-named sub-directories couldn’t be differentiated and so they’d conflict.

Using the `resolve-entry-modules-webpack-plugin` means each entry is quarantined from the other.

Fixes #12.